### PR TITLE
to deploy the model by pushing it to replicate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-sdxl-cache/
 refiner-cache/
 safety-cache/
 trained-model/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ cog train -i input_images=@example_datasets/__data.zip -i use_face_detection_ins
 cog run -p 5000 python -m cog.server.http
 ```
 
+## Push to Replicate
+
+to push the trainable model to replicate, execute the following commands:
+
+```bash
+chmod +x script/download_weights
+```
+
+```bash
+cog run script/download_weights
+```
+
+```bash
+cog push r8.im/"your model name in replicate here"
+```
+
 ## Update notes
 
 **2023-08-17**

--- a/script/download_weights
+++ b/script/download_weights
@@ -1,3 +1,4 @@
+#!/usr/bin/env python 
 # Run this before you deploy it on replicate, because if you don't
 # whenever you run the model, it will download the weights from the
 # internet, which will take a long time.


### PR DESCRIPTION
Some changes have been made for users who want to deploy the trainable model by pushing it to replicate.com. 

If these changes are not made, the following error is encountered: 

`Error no file named pytorch_model.bin, tf_model.h5, model.ckpt.index or flax_model.msgpack found in directory ./sdxl-cache.
`
https://replicate.com/p/qy7ge2tb2mwwc7guoi7mztttpe?input=form

For this reason, the `download_weights.py` script should be unextended and can be run with `cog run ...`, also `./sdxl-cache` should be removed from `dockerignore`. 